### PR TITLE
PostgreSQL で SchemaTool::dropSchema() が動作しない問題の改善

### DIFF
--- a/Resource/doctrine/migrations/Version20160317161732.php
+++ b/Resource/doctrine/migrations/Version20160317161732.php
@@ -77,10 +77,7 @@ class Version20160317161732 extends AbstractMigration
             'plg_oauth2_scope'
         );
         foreach ($tables as $table) {
-            $sql = 'DROP TABLE '.$table;
-            $stmt = $this->connection->prepare($sql);
-            $stmt->execute();
-            $stmt->closeCursor();
+            $schema->dropTable($table);
         }
 
         if ($this->connection->getDatabasePlatform()->getName() == "postgresql") {
@@ -96,10 +93,7 @@ class Version20160317161732 extends AbstractMigration
                 'plg_oauth2_user_id_seq'
             );
             foreach ($sequences as $sequence) {
-                $sql = 'DROP SEQUENCE '.$sequence;
-                $stmt = $this->connection->prepare($sql);
-                $stmt->execute();
-                $stmt->closeCursor();
+                $schema->dropSequence($sequence);
             }
         }
     }

--- a/Resource/doctrine/migrations/Version20160317161732.php
+++ b/Resource/doctrine/migrations/Version20160317161732.php
@@ -45,7 +45,7 @@ class Version20160317161732 extends AbstractMigration
             $metadatas[] = $em->getMetadataFactory()->getMetadataFor('\\Plugin\\EccubeApi\\Entity\\OAuth2\\'.$class);
         }
         $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($em);
-        $schemaTool->dropSchema($metadatas);
+        // $schemaTool->dropSchema($metadatas);
         $schemaTool->createSchema($metadatas);
 
         $scopes = array('read', 'write', 'openid', 'offline_access');
@@ -64,23 +64,43 @@ class Version20160317161732 extends AbstractMigration
     public function down(Schema $schema)
     {
         // this down() migration is auto-generated, please modify it to your needs
-        $classes = array(
-            self::AUTHORIZATION_CODE,
-            self::SCOPE,
-            self::USERINFO,
-            self::USERINFO_ADDRESS,
-            self::PUBLIC_KEY,
-            self::REFRESH_TOKEN,
-            self::ACCESS_TOKEN,
-            self::USER,
-            self::CLIENT
+        // XXX PostgreSQL で schemaTool::dropSchema() がうまく動作しないため、個別に削除
+        $tables = array(
+            'plg_oauth2_access_token',
+            'plg_oauth2_refresh_token',
+            'plg_oauth2_authorization_code',
+            'plg_oauth2_user',
+            'plg_oauth2_client',
+            'plg_oauth2_openid_public_key',
+            'plg_oauth2_openid_userinfo',
+            'plg_oauth2_openid_userinfo_address',
+            'plg_oauth2_scope'
         );
-        $app = \Eccube\Application::getInstance();
-        $em = $app['orm.em'];
-        foreach ($classes as $class) {
-            $metadatas[] = $em->getMetadataFactory()->getMetadataFor('\\Plugin\\EccubeApi\\Entity\\OAuth2\\'.$class);
+        foreach ($tables as $table) {
+            $sql = 'DROP TABLE '.$table;
+            $stmt = $this->connection->prepare($sql);
+            $stmt->execute();
+            $stmt->closeCursor();
         }
-        $schemaTool = new \Doctrine\ORM\Tools\SchemaTool($em);
-        $schemaTool->dropSchema($metadatas);
+
+        if ($this->connection->getDatabasePlatform()->getName() == "postgresql") {
+            $sequences = array(
+                'plg_oauth2_access_token_id_seq',
+                'plg_oauth2_authorization_code_id_seq',
+                'plg_oauth2_client_id_seq',
+                'plg_oauth2_openid_public_key_id_seq',
+                'plg_oauth2_openid_userinfo_address_id_seq',
+                'plg_oauth2_openid_userinfo_id_seq',
+                'plg_oauth2_refresh_token_id_seq',
+                'plg_oauth2_scope_id_seq',
+                'plg_oauth2_user_id_seq'
+            );
+            foreach ($sequences as $sequence) {
+                $sql = 'DROP SEQUENCE '.$sequence;
+                $stmt = $this->connection->prepare($sql);
+                $stmt->execute();
+                $stmt->closeCursor();
+            }
+        }
     }
 }


### PR DESCRIPTION
- Doctrine\DBAL\Exception\DriverException: An exception occurred while
  executing 'SHOW search_path' となってしまうため、テーブル個別に削除
