### PR TITLE
Composerでインストールする場合の対応

### DIFF
--- a/ServiceProvider/EccubeApiServiceProvider.php
+++ b/ServiceProvider/EccubeApiServiceProvider.php
@@ -12,7 +12,10 @@
 
 namespace Plugin\EccubeApi\ServiceProvider;
 
-require_once(__DIR__ . '/../vendor/autoload.php');
+$autoload = __DIR__ . '/../vendor/autoload.php';
+if (file_exists($autoload) && is_readable($autoload)) {
+    require_once($autoload);
+}
 
 use Eccube\Application;
 use Monolog\Handler\FingersCrossed\ErrorLevelActivationStrategy;


### PR DESCRIPTION
Composerでインストールする場合はvendorディレクトリをプラグインアーカイブに含めないので、vendor/autoload.phpを読み込もうとして発生するエラーを回避するようにしました。

関連: https://github.com/EC-CUBE/ec-cube/issues/2034